### PR TITLE
Fix: BookmarkPicker modal z-index overlap issue (#3)

### DIFF
--- a/octopath-newtab/src/components/Bookmarks/BookmarkPicker.module.css
+++ b/octopath-newtab/src/components/Bookmarks/BookmarkPicker.module.css
@@ -5,6 +5,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  /* Use very high z-index to ensure modal appears above all other content */
+  z-index: 9999;
   backdrop-filter: blur(8px);
   animation: fadeIn 0.2s ease-out;
 }


### PR DESCRIPTION
## 問題

Issue #3: BookmarkPickerモーダルが検索バーとOCTOPATHタイトルの下に隠れてしまい、操作できない問題。

## 原因

React Portalを使用して`document.body`にモーダルをレンダリングしていたが、z-indexが設定されていなかったため、他の要素（`z-index: var(--z-content)`が設定されている要素）の下に表示されていた。

## 解決策

BookmarkPickerモーダルの`.backdrop`に`z-index: 9999`を明示的に設定。これにより、すべてのコンテンツの上にモーダルが表示されるようになった。

## 変更内容

- `src/components/Bookmarks/BookmarkPicker.module.css`: `.backdrop`に`z-index: 9999`を追加

## テスト

- ✅ `npm run build` 成功
- ✅ `npm run lint` 成功
- ✅ TypeScriptコンパイル成功

## 動作確認

拡張機能を読み込んで以下を確認:
1. 「From Chrome」ボタンをクリック
2. モーダルが最前面に表示されること
3. 検索バーやタイトルと重ならないこと
4. モーダル内のブックマークが選択できること

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)